### PR TITLE
addind expect case to before_action :authenticate_user! in the articl…

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,5 +1,5 @@
 class ArticlesController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: [:show, :index]
 
   def index
     @articles = Article.all

--- a/spec/features/only_allow_logged_in_users_to_create_articles_spec.rb
+++ b/spec/features/only_allow_logged_in_users_to_create_articles_spec.rb
@@ -1,11 +1,21 @@
 RSpec.describe "User authentication required for accessing 'Write Article',", type: feature do
-  feature "user should not be able to write articles without logging in" do
+  feature "visitors should be able to see articles without logging in" do
     before do
       visit "/"
     end
 
     it "Write Article link is not visible" do
-      expect(page).to_not have_content "Write Article"
+      expect(page).to have_content "Write Article"
+    end
+  end
+
+  feature "User should not be able to write articles without logging in" do
+    before do
+       visit "/"
+       click_on "Write Article"
+    end
+    it "Write Article require login" do
+      expect(page).to have_content "Log in"
     end
   end
 


### PR DESCRIPTION
addind expect case to before_action :authenticate_user! in the articles controller, :show and :index should be visible for visitors only. Updating unit test only_allow_logged_in_users_to_create_articles_spec.rb to test if articles is visible for unregistered visitors and that Write Articles is only accessable by logging in, test passes green"